### PR TITLE
Retrieve current page properly during pagination

### DIFF
--- a/src/Handler/BlogIndexHandler.php
+++ b/src/Handler/BlogIndexHandler.php
@@ -47,8 +47,6 @@ final readonly class BlogIndexHandler implements RequestHandlerInterface
         $allArticles = $this->itemLister->getArticles();
         usort($allArticles, new SortByReverseDateOrder());
 
-        $currentPage = $request->getQueryParams()['current'] ?? 1;
-
         $publishedArticles = new PublishedItemFilterIterator(
             new ArrayIterator($allArticles)
         );
@@ -57,7 +55,8 @@ final readonly class BlogIndexHandler implements RequestHandlerInterface
             ? self::DEFAULT_PAGE
             : (int) ceil(iterator_count($publishedArticles) / $this->itemsPerPage);
 
-        $data = [
+        $currentPage = (int) $request->getAttribute('current', 1);
+        $data        = [
             'articles'  => new LimitIterator(
                 $publishedArticles,
                 offset: $this->getItemLimitOffset($currentPage, $this->itemsPerPage),

--- a/test/Integration/BlogIndexPageTest.php
+++ b/test/Integration/BlogIndexPageTest.php
@@ -35,9 +35,10 @@ final class BlogIndexPageTest extends TestCase
         /** @var ServerRequestInterface $request */
         $request  = $this->container->get(ServerRequestInterface::class)();
         $response = $handler->handle(
-            $request->withQueryParams([
-                'current' => $pageNumber,
-            ])
+            $request->withAttribute(
+                'current',
+                $pageNumber,
+            )
         );
 
         self::assertInstanceOf(HtmlResponse::class, $response);

--- a/test/Unit/Handler/BlogIndexHandlerTest.php
+++ b/test/Unit/Handler/BlogIndexHandlerTest.php
@@ -61,10 +61,9 @@ class BlogIndexHandlerTest extends TestCase
         $request = $this->createMock(ServerRequestInterface::class);
         $request
             ->expects($this->once())
-            ->method("getQueryParams")
-            ->willReturn([
-                "current" => $currentPage,
-            ]);
+            ->method("getAttribute")
+            ->with('current', 1)
+            ->willReturn($currentPage);
 
         $handler = new BlogIndexHandler($template, $itemLister);
 
@@ -203,10 +202,9 @@ class BlogIndexHandlerTest extends TestCase
         $request = $this->createMock(ServerRequestInterface::class);
         $request
             ->expects($this->once())
-            ->method("getQueryParams")
-            ->willReturn([
-                "current" => $currentPage,
-            ]);
+            ->method("getAttribute")
+            ->with('current', 1)
+            ->willReturn($currentPage);
 
         $handler  = new BlogIndexHandler($template, $itemLister);
         $response = $handler->handle($request);


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

This change corrects a bug where the current page number, set in the request (route) attribute "current" was mistakenly being sought in the request's query parameters. By changing this, pagination will work properly.