### PR TITLE
Finish implementing pagination

### DIFF
--- a/src/Handler/BlogIndexHandler.php
+++ b/src/Handler/BlogIndexHandler.php
@@ -16,6 +16,7 @@ use Settermjd\MarkdownBlog\Iterator\PublishedItemFilterIterator;
 use Settermjd\MarkdownBlog\Sorter\SortByReverseDateOrder;
 
 use function ceil;
+use function count;
 use function iterator_count;
 use function usort;
 
@@ -64,9 +65,15 @@ final readonly class BlogIndexHandler implements RequestHandlerInterface
             ),
             'current'   => $currentPage,
             'pageCount' => $pageCount,
-            'previous'  => $currentPage > self::DEFAULT_PAGE,
-            'next'      => $currentPage < $pageCount,
         ];
+
+        if ($currentPage > self::DEFAULT_PAGE) {
+            $data['previous'] = $currentPage - 1;
+        }
+
+        if ($this->hasNextPage($currentPage, count($allArticles), $this->itemsPerPage)) {
+            $data['next'] = $currentPage + 1;
+        }
 
         return new HtmlResponse($this->renderer->render('blog::blog', $data));
     }

--- a/src/Handler/PaginationTrait.php
+++ b/src/Handler/PaginationTrait.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Settermjd\MarkdownBlog\Handler;
 
+use function ceil;
+
 /**
  * This trait contains utility functions for handling and simplifying pagination
  *
@@ -18,5 +20,15 @@ trait PaginationTrait
         int $itemsPerPage = BlogIndexHandler::ITEMS_PER_PAGE
     ): int {
         return $currentPage === 1 ? 0 : ($currentPage - 1) * $itemsPerPage;
+    }
+
+    public function hasNextPage(int $currentPage, int $totalItems, int $itemsPerPage): bool
+    {
+        return $currentPage < (int) ceil($totalItems / $itemsPerPage);
+    }
+
+    public function hasPreviousPage(int $currentPage): bool
+    {
+        return $currentPage > 1;
     }
 }

--- a/templates/blog/laminas/blog.phtml
+++ b/templates/blog/laminas/blog.phtml
@@ -34,5 +34,21 @@
                 </div>
             <?php endforeach ?>
         </div>
+        <?php
+        $data = [
+            'current' => $current,
+            'pageCount' => $pageCount,
+        ];
+        if (isset($previous)) {
+            $data['previous'] = $previous;
+        }
+        if (isset($page)) {
+            $data['page'] = $page;
+        }
+        if (isset($next)) {
+            $data['next'] = $next;
+        }
+        ?>
+        <?= $this->partial('blog::includes/pagination', $data); ?>
     <?php endif ?>
 </div>

--- a/templates/blog/laminas/includes/pagination.phtml
+++ b/templates/blog/laminas/includes/pagination.phtml
@@ -1,21 +1,21 @@
 <?php if (isset($this->pageCount) && $this->pageCount > 1): ?>
-    <nav>
+    <nav id="navigation">
         <ul>
             <!-- Previous page link -->
             <?php if (isset($this->previous) && ! empty($this->previous)): ?>
-                <li>
-                    <a>&Larr;</a>
+                <li id="prev">
+                    <a href="/blog/<?= $this->escapeHtml($previous) ?>">&Larr;</a>
                 </li>
             <?php endif ?>
 
             <!-- Numbered page links -->
             <?php foreach (range(1, $this->pageCount) as $page): ?>
                 <?php if ($page === $current): ?>
-                    <li>
+                    <li id="page-<?= $this->escapeHtml($page) ?>">
                         <a><?= $this->escapeHtml($page) ?></a>
                     </li>
                 <?php else: ?>
-                    <li>
+                    <li id="current-page">
                         <span><?= $this->escapeHtml($page) ?></span>
                     </li>
                 <?php endif ?>
@@ -23,8 +23,8 @@
 
             <!-- Next page link -->
             <?php if (isset($this->next) && ! empty($this->next)): ?>
-                <li>
-                    <a>&Rarr;</a>
+                <li id="next">
+                    <a href="/blog/<?= $this->escapeHtml($next) ?>">&Rarr;</a>
                 </li>
             <?php endif ?>
         </ul>

--- a/templates/blog/plates/blog.phtml
+++ b/templates/blog/plates/blog.phtml
@@ -33,6 +33,21 @@
                 </div>
             <?php endforeach ?>
         </div>
-        <?= $this->insert('blog::includes/pagination') ?>
+        <?php
+        $data = [
+            'current' => $current,
+            'pageCount' => $pageCount,
+        ];
+        if (isset($previous)) {
+            $data['previous'] = $previous;
+        }
+        if (isset($page)) {
+            $data['page'] = $page;
+        }
+        if (isset($next)) {
+            $data['next'] = $next;
+        }
+        ?>
+        <?= $this->insert('blog::includes/pagination', $data) ?>
     <?php endif ?>
 </div>

--- a/templates/blog/plates/includes/pagination.phtml
+++ b/templates/blog/plates/includes/pagination.phtml
@@ -1,21 +1,21 @@
 <?php if (isset($pageCount) && $pageCount > 1): ?>
-    <nav>
+    <nav id="navigation">
         <ul>
             <!-- Previous page link -->
             <?php if (isset($previous) && ! empty($previous)): ?>
-                <li>
-                    <a>&Larr;</a>
+                <li id="prev">
+                    <a href="/blog/<?= $this->e($previous) ?>">&Larr;</a>
                 </li>
             <?php endif ?>
 
             <!-- Numbered page links -->
             <?php foreach (range(1, $pageCount) as $page): ?>
                 <?php if ($page === $current): ?>
-                    <li>
-                        <a>{<?= $this->e($page) ?></a>
+                    <li id="page-<?= $this->e($page) ?>">
+                        <a><?= $this->e($page) ?></a>
                     </li>
                 <?php else: ?>
-                    <li>
+                    <li id="current-page">
                         <span><?= $this->e($page) ?></span>
                     </li>
                 <?php endif ?>
@@ -23,8 +23,8 @@
 
             <!-- Next page link -->
             <?php if (isset($next) && ! empty($next)): ?>
-                <li>
-                    <a>&Rarr;</a>
+                <li id="next">
+                    <a href="/blog/<?= $this->e($next) ?>">&Rarr;</a>
                 </li>
             <?php endif ?>
         </ul>

--- a/templates/blog/twig/includes/pagination.html.twig
+++ b/templates/blog/twig/includes/pagination.html.twig
@@ -1,23 +1,23 @@
 {% if pageCount is defined and not pageCount is empty and pageCount > 1 %}
-    <nav>
+    <nav id="pagination">
         <ul>
             <!-- Previous page link -->
             {% if previous is defined and not previous is empty %}
-                <li>
-                    <a>&Larr;</a>
+                <li id="prev">
+                    <a href="/blog/{{ previous }}">&Larr;</a>
                 </li>
             {% endif %}
 
             <!-- Numbered page links -->
             {% for page in range(1, pageCount)%}
                 {% if page != current %}
-                    <li>
-                        <a>
+                    <li id="page-{{ page }}">
+                        <a href="/blog/{{ page }}">
                             {{ page }}
                         </a>
                     </li>
                 {% else %}
-                    <li>
+                    <li id="current-page">
                         <span>{{ page }}</span>
                     </li>
                 {% endif %}
@@ -25,8 +25,8 @@
 
             <!-- Next page link -->
             {% if next is defined and not next is empty %}
-                <li>
-                    <a>&Rarr;</a>
+                <li id="next">
+                    <a href="/blog/{{ next }}">&Rarr;</a>
                 </li>
             {% endif %}
         </ul>

--- a/test/Integration/BlogIndexPageTest.php
+++ b/test/Integration/BlogIndexPageTest.php
@@ -17,14 +17,18 @@ final class BlogIndexPageTest extends TestCase
 {
     use SetupHelperTrait;
 
-    #[TestWith([ViewLayer::LaminasView, 1, 10])]
-    #[TestWith([ViewLayer::LaminasView, 2, 3])]
-    #[TestWith([ViewLayer::Plates, 1, 10])]
-    #[TestWith([ViewLayer::Twig, 1, 10])]
+    #[TestWith([ViewLayer::Twig, 1, 10, false, true])]
+    #[TestWith([ViewLayer::Twig, 2, 3, true, false])]
+    #[TestWith([ViewLayer::Plates, 1, 10, false, true])]
+    #[TestWith([ViewLayer::Plates, 2, 3, true, false])]
+    #[TestWith([ViewLayer::LaminasView, 1, 10, false, true])]
+    #[TestWith([ViewLayer::LaminasView, 2, 3, true, false])]
     public function testCanRenderTheBlogIndexRouteWhenPostsAreAvailable(
         ViewLayer $viewLayer,
         int $pageNumber,
-        int $blogItemCount
+        int $blogItemCount,
+        bool $hasPrevious,
+        bool $hasNext,
     ): void {
         $_ENV['TEMPLATE_LAYER'] = $viewLayer->value;
 
@@ -47,6 +51,16 @@ final class BlogIndexPageTest extends TestCase
 
         $subCrawler = $crawler->filterXPath('//div[@id="blog-items"]/div');
         self::assertCount($blogItemCount, $subCrawler);
+
+        if ($hasPrevious) {
+            $subCrawler = $crawler->filterXPath('//li[@id="prev"]');
+            self::assertCount(1, $subCrawler);
+        }
+
+        if ($hasNext) {
+            $subCrawler = $crawler->filterXPath('//li[@id="next"]');
+            self::assertCount(1, $subCrawler);
+        }
     }
 
     #[TestWith([ViewLayer::LaminasView], "Test rendering a blog article using the laminas-view template renderer")]

--- a/test/Unit/Handler/BlogIndexHandlerTest.php
+++ b/test/Unit/Handler/BlogIndexHandlerTest.php
@@ -24,8 +24,8 @@ class BlogIndexHandlerTest extends TestCase
         array $articles,
         int $currentPage,
         int $pageCount,
-        bool $previous,
-        bool $next
+        int|null $previous = null,
+        int|null $next = null
     ) {
         $publishedArticles = new LimitIterator(
             new PublishedItemFilterIterator(
@@ -39,9 +39,15 @@ class BlogIndexHandlerTest extends TestCase
             'articles'  => $publishedArticles,
             'current'   => $currentPage,
             'pageCount' => $pageCount,
-            'previous'  => $previous,
-            'next'      => $next,
         ];
+
+        if ($previous !== null) {
+            $data['previous'] = $previous;
+        }
+
+        if ($next !== null) {
+            $data['next'] = $next;
+        }
 
         /** @var TemplateRendererInterface&MockObject $template */
         $template = $this->createMock(TemplateRendererInterface::class);
@@ -89,8 +95,6 @@ class BlogIndexHandlerTest extends TestCase
                 ],
                 1,
                 1,
-                false,
-                false,
             ],
             "On the second of two pages of blog items, showing one item per page, with the ability to go back to the previous page" => [
                 [
@@ -127,8 +131,7 @@ class BlogIndexHandlerTest extends TestCase
                 ],
                 2,
                 1,
-                true,
-                false,
+                1,
             ],
             // phpcs:enable Generic.Files.LineLength
             "On the first page of one page of blog items with a total of one blog items" => [
@@ -166,8 +169,6 @@ class BlogIndexHandlerTest extends TestCase
                 ],
                 1,
                 1,
-                false,
-                false,
             ],
         ];
     }
@@ -180,8 +181,6 @@ class BlogIndexHandlerTest extends TestCase
             'articles'  => new LimitIterator(new PublishedItemFilterIterator(new ArrayIterator([]))),
             'current'   => $currentPage,
             'pageCount' => 1,
-            'previous'  => false,
-            'next'      => false,
         ];
 
         /** @var ItemListerInterface&MockObject $itemLister */

--- a/test/Unit/Handler/PaginationTraitTest.php
+++ b/test/Unit/Handler/PaginationTraitTest.php
@@ -31,4 +31,28 @@ class PaginationTraitTest extends TestCase
     ): void {
         $this->assertSame($expectedOffset, $this->getItemLimitOffset($currentPage, $itemsPerPage));
     }
+
+    #[TestWith([1, 10, 10, false])]
+    #[TestWith([1, 28, 10, true])]
+    #[TestWith([3, 28, 10, false])]
+    public function testCanDetermineIfNextPageExistsCorrectly(
+        int $currentPage,
+        int $totalItems,
+        int $itemsPerPage,
+        bool $hasNextPage
+    ): void {
+        $this->assertSame($hasNextPage, $this->hasNextPage($currentPage, $totalItems, $itemsPerPage));
+    }
+
+    #[TestWith([1, false])]
+    #[TestWith([1, false])]
+    #[TestWith([2, true])]
+    #[TestWith([3, true])]
+    #[TestWith([1, false])]
+    public function testCanDetermineIfPreviousPageExistsCorrectly(
+        int $currentPage,
+        bool $hasPreviousPage,
+    ): void {
+        $this->assertSame($hasPreviousPage, $this->hasPreviousPage($currentPage));
+    }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

This change, rough as it is, finishes implementing the final pieces of pagination. It does the by updating all of the templates to include next and previous links when appropriate, to include pagination when it makes sense, and to set next and previous links if there is something to link to in these instances.