### PR TITLE
Fix config cache bug

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,6 +62,7 @@
         "monolog/monolog": "^3.9",
         "psr/cache": "^3.0",
         "psr/simple-cache": "^3.0",
+        "samdark/sitemap": "^2.4",
         "twig/intl-extra": "^3.21",
         "twig/markdown-extra": "^3.21",
         "zetacomponents/feed": "^1.4.5"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a1befa0b2cdc35c44c0799462dae4b5e",
+    "content-hash": "d301a472104b8d96eabb4c73ad790b7b",
     "packages": [
         {
             "name": "brick/varexporter",
@@ -3204,6 +3204,65 @@
                 "source": "https://github.com/php-fig/simple-cache/tree/3.0.0"
             },
             "time": "2021-10-29T13:26:27+00:00"
+        },
+        {
+            "name": "samdark/sitemap",
+            "version": "2.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/samdark/sitemap.git",
+                "reference": "cf514750781275ad90fc9a828b4330c9c5ccba98"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/samdark/sitemap/zipball/cf514750781275ad90fc9a828b4330c9c5ccba98",
+                "reference": "cf514750781275ad90fc9a828b4330c9c5ccba98",
+                "shasum": ""
+            },
+            "require": {
+                "ext-xmlwriter": "*",
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "samdark\\sitemap\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Alexander Makarov",
+                    "email": "sam@rmcreative.ru",
+                    "homepage": "http://rmcreative.ru/"
+                }
+            ],
+            "description": "Sitemap and sitemap index builder",
+            "homepage": "https://github.com/samdark/sitemap",
+            "keywords": [
+                "Sitemap"
+            ],
+            "support": {
+                "issues": "https://github.com/samdark/sitemap/issues",
+                "source": "https://github.com/samdark/sitemap"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/samdark",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/samdark",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2023-11-01T08:41:34+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -41,6 +41,7 @@ final class ConfigProvider
     public function __invoke(): array
     {
         return [
+            // The default blog configuration
             'blog'         => $this->getBlogConfig(),
             'dependencies' => $this->getDependencies(),
             'routes'       => $this->getRoutes(),
@@ -147,7 +148,7 @@ final class ConfigProvider
              * files from. This directory needs to be manually initialised before it
              * can be used.
              */
-            'path' => __DIR__ . '/../../../' . $path,
+            'path' => __DIR__ . '/../../' . $path,
 
             /**
              * 'parser' is the class to use to parse the Markdown file's YAML front-matter.

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -15,13 +15,11 @@ use Settermjd\MarkdownBlog\Handler\BlogIndexHandler;
 use Settermjd\MarkdownBlog\InputFilter\BlogArticleInputFilterFactory;
 use Settermjd\MarkdownBlog\Items\ItemListerFactory;
 use Settermjd\MarkdownBlog\Items\ItemListerInterface;
+use Settermjd\MarkdownBlog\RuntimeLoader\MarkdownRuntimeLoader;
 use Settermjd\MarkdownBlog\ViewLayer;
 use Settermjd\MarkdownBlog\ViewLayer\Plates\Extensions\MarkdownToHtml;
 use Twig\Extra\Intl\IntlExtension;
-use Twig\Extra\Markdown\DefaultMarkdown;
 use Twig\Extra\Markdown\MarkdownExtension;
-use Twig\Extra\Markdown\MarkdownRuntime;
-use Twig\RuntimeLoader\RuntimeLoaderInterface;
 
 /**
  * The configuration provider for the module
@@ -175,14 +173,7 @@ final class ConfigProvider
                 new MarkdownExtension(),
             ],
             'runtime_loaders' => [
-                new class implements RuntimeLoaderInterface {
-                    public function load(string $class): MarkdownRuntime|null
-                    {
-                        return MarkdownRuntime::class === $class
-                            ? new MarkdownRuntime(new DefaultMarkdown())
-                            : null;
-                    }
-                },
+                new MarkdownRuntimeLoader(),
             ],
         ];
     }

--- a/src/RuntimeLoader/MarkdownRuntimeLoader.php
+++ b/src/RuntimeLoader/MarkdownRuntimeLoader.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Settermjd\MarkdownBlog\RuntimeLoader;
+
+use Twig\Extra\Markdown\DefaultMarkdown;
+use Twig\Extra\Markdown\MarkdownRuntime;
+use Twig\RuntimeLoader\RuntimeLoaderInterface;
+
+final class MarkdownRuntimeLoader implements RuntimeLoaderInterface
+{
+    public function load(string $class): MarkdownRuntime|null
+    {
+        if (MarkdownRuntime::class === $class) {
+            return new MarkdownRuntime(new DefaultMarkdown());
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

This change removes the previous anonymous class used in _ConfigProvider.php_ replacing it with the custom `RuntimeLoader` class so that _data/cache/config-cache.php_ will be generated properly when the package is used in Mezzio applications.

The class is a custom Twig `RuntimeLoaderInterface` class for loading the `MarkdownRuntime`. It's required so that Markdown support is available in Twig, when required. The anonymous class implementation that I used
previously, for an as yet unknown reason, caused _data/cache/config-cache.php_ to break with the following error:

```bash
PHP Parse error: syntax error, unexpected token "@", expecting "]" in /app/data/cache/config-cache.php on line 200
```

If you look in the file, you'll see the following at that line:

```php
\Twig\RuntimeLoader\RuntimeLoaderInterface@anonymous^@/app/config/autoload/twig.global.php:24$d,
```